### PR TITLE
Some little changes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
+.aider*                  export-ignore
+.DS_Store                export-ignore
 /.distignore             export-ignore
 /.editorconfig           export-ignore
 /.env                    export-ignore
@@ -5,6 +7,7 @@
 /.github/                export-ignore
 /.gitignore              export-ignore
 /.php-cs-fixer.dist.php  export-ignore
+/.tx/                    export-ignore
 /language/*.po           export-ignore
 /language/*.pot          export-ignore
 /test/                   export-ignore
@@ -13,6 +16,5 @@ composer.lock            export-ignore
 docker-compose.yml       export-ignore
 Makefile                 export-ignore
 phpunit.xml              export-ignore
-README.md                export-ignore
 renovate.json            export-ignore
 test.php                 export-ignore

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,62 @@
+stages:
+  # Disabled build and upload stages until get internet connection on Gitlab Runner  
+  # - build
+  # - upload
+  - release
+
+variables:
+  # Package version should match \A(\.?[\w\+-]+\.?)+\z regular expresion.
+  # See https://docs.gitlab.com/ee/user/packages/generic_packages/#publish-a-package-file
+  PACKAGE_VERSION: "${CI_COMMIT_TAG}"
+  PACKAGE_BINARY: "decker-${PACKAGE_VERSION}"
+  PACKAGE_REGISTRY_URL: "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/generic/decker/${PACKAGE_VERSION}"
+
+# Disabled build and upload stages until get internet connection on Gitlab Runner
+# build:
+#   stage: build
+#   only:
+#     - tags
+#   before_script:
+#     - apt-get update && apt-get install -y make zip composer
+#     - composer --version
+#   script:
+#     - make package VERSION="${PACKAGE_VERSION}"
+#     - ls -lh "decker-${PACKAGE_VERSION}.zip"
+#   artifacts:
+#     paths:
+#       - "decker-${PACKAGE_VERSION}.zip"
+#     expire_in: 1 week
+
+# upload:
+#   stage: upload
+#   image: curlimages/curl:latest
+#   only:
+#     - tags
+#   needs: ["build"]
+#   script:
+#     - |
+#       curl --header "JOB-TOKEN: ${CI_JOB_TOKEN}" \
+#            --upload-file "${PACKAGE_BINARY}.zip" \
+#            "${PACKAGE_REGISTRY_URL}/${PACKAGE_BINARY}.zip"
+
+release:
+  stage: release
+  image: registry.gitlab.com/gitlab-org/release-cli:latest
+  only:
+    - tags
+  # Disabled build and upload stages until get internet connection on Gitlab Runner      
+  # needs: ["upload"]
+
+  script:
+    - echo "Creating GitLab release for tag ${PACKAGE_VERSION}"
+  release:
+    name: "Release ${PACKAGE_VERSION}"
+    tag_name: "${CI_COMMIT_TAG}"
+    description: "Release for ${PACKAGE_VERSION}"
+    assets:
+      links:
+        - name: "${PACKAGE_BINARY}.zip"
+          # Disabled build and upload stages until get internet connection on Gitlab Runner
+          # url: "${PACKAGE_REGISTRY_URL}/${PACKAGE_BINARY}.zip"
+          url: "https://github.com/ateeducacion/omeka-s-IsolatedSites/releases/download/${PACKAGE_VERSION}/${PACKAGE_BINARY}.zip"
+

--- a/Makefile
+++ b/Makefile
@@ -81,13 +81,15 @@ package:
 	@echo "Updating version to $(VERSION) in module.ini..."
 	$(SED_INPLACE) 's/^\([[:space:]]*version[[:space:]]*=[[:space:]]*\).*$$/\1"$(VERSION)"/' config/module.ini
 	@echo "Creating ZIP archive: IsolatedSites-$(VERSION).zip..."
-	composer archive --format=zip --file="IsolatedSites-$(VERSION)"
+	composer archive --format=zip --file="IsolatedSites-$(VERSION)-raw"
+	@echo "Repacking into proper structure..."
+	mkdir -p tmpzip/IsolatedSites && unzip -q IsolatedSites-$(VERSION)-raw.zip -d tmpzip/IsolatedSites && \
+	cd tmpzip && zip -qr ../IsolatedSites-$(VERSION).zip IsolatedSites && cd .. && rm -rf tmpzip IsolatedSites-$(VERSION)-raw.zip
 	@echo "Restoring version to 0.0.0 in module.ini..."
 	$(SED_INPLACE) 's/^\([[:space:]]*version[[:space:]]*=[[:space:]]*\).*$$/\1"0.0.0"/' config/module.ini
 
 # Generate .pot template from translate() and // @translate
 generate-pot:
-	echo "<?php translate(\"Translate module texts\"); ?>" > language/empty.php
 	@echo "Extracting strings using xgettext..."
 	find . -path ./vendor -prune -o \( -name '*.php' -o -name '*.phtml' \) -print \
 	| xargs xgettext \
@@ -100,7 +102,7 @@ generate-pot:
 	vendor/zerocrates/extract-tagged-strings/extract-tagged-strings.php > language/tagged.pot
 	@echo "Merging xgettext.pot and tagged.pot into template.pot..."
 	msgcat language/xgettext.pot language/tagged.pot --use-first -o language/template.pot
-	@rm -f language/xgettext.pot language/tagged.pot language/empty.php
+	@rm -f language/xgettext.pot language/tagged.pot
 	@echo "Generated language/template.pot"
 
 


### PR DESCRIPTION
This pull request includes changes to the `.gitattributes` file and the `Makefile` to improve the export process and the packaging of the project. The most important changes include adding new patterns to the `.gitattributes` file for export-ignore, modifying the packaging process in the `Makefile`, and cleaning up unnecessary files.

### Improvements to export-ignore patterns:

* [`.gitattributes`](diffhunk://#diff-618cd5b83d62060ba3d027e314a21ceaf75d36067ff820db126642944145393eR1-R10): Added new patterns such as `.aider*`, `.DS_Store`, and `/.tx/` to be ignored during export.

### Modifications to packaging process:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L84-L90): Updated the `package` target to create a temporary directory structure for the ZIP archive, ensuring a proper structure for the final package.

### Cleanup of unnecessary files:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L103-R105): Removed the creation of `language/empty.php` and its subsequent deletion in the `generate-pot` target, simplifying the process.
[Copilot is generating a summary...]