### PR TITLE
16 isolatedsites module filters items in public site view should apply to admin only

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -18,6 +18,7 @@ use IsolatedSites\Listener\ModifyUserSettingsFormListener;
 use IsolatedSites\Listener\ModifyItemSetQueryListener;
 use IsolatedSites\Listener\ModifyAssetQueryListener;
 use IsolatedSites\Listener\ModifySiteQueryListener;
+use IsolatedSites\Listener\ModifyMediaQueryListener;
 
 /**
  * Main class for the IsoltatedSites module.
@@ -120,6 +121,13 @@ class Module extends AbstractModule
             'Omeka\Api\Adapter\SiteAdapter',
             'api.search.query',
             [$this->serviceLocator->get(ModifySiteQueryListener::class), '__invoke']
+        );
+
+        // For limit the view of Media
+        $sharedEventManager->attach(
+            'Omeka\Api\Adapter\MediaAdapter',
+            'api.search.query',
+            [$this->serviceLocator->get(ModifyMediaQueryListener::class), '__invoke']
         );
     }
     /**

--- a/Module.php
+++ b/Module.php
@@ -90,8 +90,8 @@ class Module extends AbstractModule
         );
 
         $sharedEventManager->attach(
-            \Omeka\Form\UserForm::class,
-            'form.submit',
+            'CAS\Controller\LoginController',
+            'cas.user.create.post',
             [$this->serviceLocator->get(ModifyUserSettingsFormListener::class), 'handleUserSettings']
         );
 

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -15,6 +15,7 @@ use IsolatedSites\Listener\ModifyQueryListener;
 use IsolatedSites\Listener\ModifyItemSetQueryListener;
 use IsolatedSites\Listener\ModifyAssetQueryListener;
 use IsolatedSites\Listener\ModifySiteQueryListener;
+use IsolatedSites\Listener\ModifyMediaQueryListener;
 use Laminas\Mvc\Application;
 
 return [
@@ -75,6 +76,14 @@ return [
             },
             ModifySiteQueryListener::class => function ($services) {
                 return new ModifySiteQueryListener(
+                    $services->get('Omeka\AuthenticationService'),
+                    $services->get('Omeka\Settings\User'),
+                    $services->get('Omeka\Connection'),
+                    $services->get('Application')
+                );
+            },
+            ModifyMediaQueryListener::class => function ($services) {
+                return new ModifyMediaQueryListener(
                     $services->get('Omeka\AuthenticationService'),
                     $services->get('Omeka\Settings\User'),
                     $services->get('Omeka\Connection'),

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -15,6 +15,7 @@ use IsolatedSites\Listener\ModifyQueryListener;
 use IsolatedSites\Listener\ModifyItemSetQueryListener;
 use IsolatedSites\Listener\ModifyAssetQueryListener;
 use IsolatedSites\Listener\ModifySiteQueryListener;
+use Laminas\Mvc\Application;
 
 return [
     'view_manager' => [
@@ -49,30 +50,35 @@ return [
                 );
             },
             ModifyQueryListener::class => function ($container) {
+                //$routeMatch = $application->getMvcEvent()->getRouteMatch();
                 return new ModifyQueryListener(
                     $container->get('Omeka\AuthenticationService'),
                     $container->get('Omeka\Settings\User'),
-                    $container->get('Omeka\Connection')
+                    $container->get('Omeka\Connection'),
+                    $container->get('Application')
                 );
             },
             ModifyItemSetQueryListener::class => function ($services) {
                 return new ModifyItemSetQueryListener(
                     $services->get('Omeka\AuthenticationService'),
                     $services->get('Omeka\Settings\User'),
-                    $services->get('Omeka\Connection')
+                    $services->get('Omeka\Connection'),
+                    $services->get('Application')
                 );
             },
             ModifyAssetQueryListener::class => function ($services) {
                 return new ModifyAssetQueryListener(
                     $services->get('Omeka\AuthenticationService'),
-                    $services->get('Omeka\Settings\User')
+                    $services->get('Omeka\Settings\User'),
+                    $services->get('Application')
                 );
             },
             ModifySiteQueryListener::class => function ($services) {
                 return new ModifySiteQueryListener(
                     $services->get('Omeka\AuthenticationService'),
                     $services->get('Omeka\Settings\User'),
-                    $services->get('Omeka\Connection')
+                    $services->get('Omeka\Connection'),
+                    $services->get('Application')
                 );
             },
         ],

--- a/config/module.ini
+++ b/config/module.ini
@@ -1,6 +1,6 @@
 [info]
 name         = "IsolatedSites"
-version      = "1.0.0"
+version      = "v1.0.0"
 author       = "Área de Tecnología Educativa"
 description  = "Allows filtering out items from sites user where has no role from the admin browse page in Omeka S"
 module_link  = "https://github.com/ateeducacion/omeka-s-IsolatedSites"

--- a/src/Listener/ModifyAssetQueryListener.php
+++ b/src/Listener/ModifyAssetQueryListener.php
@@ -10,13 +10,16 @@ class ModifyAssetQueryListener
 {
     private $authService;
     private $userSettings;
+    private $application;
 
     public function __construct(
         AuthenticationService $authService,
-        UserSettings $userSettings
+        UserSettings $userSettings,
+        $application
     ) {
         $this->authService = $authService;
         $this->userSettings = $userSettings;
+        $this->application = $application;
     }
 
     /**
@@ -28,8 +31,13 @@ class ModifyAssetQueryListener
     {
         $user = $this->authService->getIdentity();
 
-        // Don't limit assets for global admins or public users
-        if (!$user || $user->getRole() === 'global_admin') {
+        // Check if we're in the admin interface
+        $routeMatch = $this->application->getMvcEvent()->getRouteMatch();
+        $routeName = $routeMatch ? $routeMatch->getMatchedRouteName() : '';
+        $isAdmin = strpos($routeName, 'admin') === 0;
+
+        // Only apply filtering in admin interface for non-global-admin users
+        if (!$isAdmin || !$user || $user->getRole() === 'global_admin') {
             return;
         }
 

--- a/src/Listener/ModifyItemSetQueryListener.php
+++ b/src/Listener/ModifyItemSetQueryListener.php
@@ -12,15 +12,18 @@ class ModifyItemSetQueryListener
     private $authService;
     private $userSettings;
     private $connection;
+    private $application;
 
     public function __construct(
         AuthenticationService $authService,
         UserSettings $userSettings,
-        Connection $connection
+        Connection $connection,
+        $application
     ) {
         $this->authService = $authService;
         $this->userSettings = $userSettings;
         $this->connection = $connection;
+        $this->application = $application;
     }
 
     /**
@@ -32,8 +35,13 @@ class ModifyItemSetQueryListener
     {
         $user = $this->authService->getIdentity();
 
-        // Not limit the view of itemsets to global_admins or not_logged users (public view)
-        if (!$user || $user->getRole() === 'global_admin') {
+        // Check if we're in the admin interface
+        $routeMatch = $this->application->getMvcEvent()->getRouteMatch();
+        $routeName = $routeMatch ? $routeMatch->getMatchedRouteName() : '';
+        $isAdmin = strpos($routeName, 'admin') === 0;
+
+        // Only apply filtering in admin interface for non-global-admin users
+        if (!$isAdmin || !$user || $user->getRole() === 'global_admin') {
             return;
         }
 

--- a/src/Listener/ModifyMediaQueryListener.php
+++ b/src/Listener/ModifyMediaQueryListener.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace IsolatedSites\Listener;
+
+use Laminas\EventManager\EventInterface;
+use Laminas\Authentication\AuthenticationService;
+use Omeka\Settings\UserSettings;
+use Doctrine\DBAL\Connection;
+use Laminas\Mvc\Application;
+
+class ModifyMediaQueryListener
+{
+    private $authService;
+    private $userSettings;
+    private $connection;
+    private $application;
+
+    public function __construct(
+        AuthenticationService $authService,
+        UserSettings $userSettings,
+        Connection $connection,
+        Application $application
+    ) {
+        $this->authService = $authService;
+        $this->userSettings = $userSettings;
+        $this->connection = $connection;
+        $this->application = $application;
+    }
+
+    /**
+     * Modify the media query based on the user's role and site permissions.
+     * Only show media attached to items that are assigned to sites where the user has permissions.
+     *
+     * @param EventInterface $event
+     */
+    public function __invoke(EventInterface $event)
+    {
+        $user = $this->authService->getIdentity();
+
+        // Check if we're in the admin interface
+        $routeMatch = $this->application->getMvcEvent()->getRouteMatch();
+        $routeName = $routeMatch ? $routeMatch->getMatchedRouteName() : '';
+        $isAdmin = strpos($routeName, 'admin') === 0;
+
+        // Only apply filtering in admin interface for non-global-admin users
+        if (!$isAdmin || !$user || $user->getRole() === 'global_admin') {
+            return;
+        }
+
+        $this->userSettings->setTargetId($user->getId());
+        $limit = $this->userSettings->get('limit_to_granted_sites', 1);
+        
+        if ($limit) {
+            // Get the sites where the user has permissions
+            $sql = 'SELECT site_id FROM site_permission WHERE user_id = :user_id';
+            $stmt = $this->connection->executeQuery($sql, ['user_id' => $user->getId()]);
+            $siteIds = $stmt->fetchFirstColumn();
+
+            // If user has no site permissions, ensure they see no media
+            if (empty($siteIds)) {
+                $siteIds = [-1]; // Use an impossible ID to return no results
+            }
+
+            $queryBuilder = $event->getParam('queryBuilder');
+            $alias = $queryBuilder->getRootAliases()[0];
+
+            // Join with the item that owns the media, then join with the sites that the item belongs to
+            $queryBuilder->innerJoin(
+                "$alias.item",
+                'i'
+            )
+                ->innerJoin(
+                    'i.sites',
+                    'site'
+                )
+                ->andWhere('site.id IN (:siteIds)')
+                ->setParameter('siteIds', $siteIds);
+        }
+    }
+}

--- a/src/Listener/ModifyQueryListener.php
+++ b/src/Listener/ModifyQueryListener.php
@@ -10,21 +10,25 @@ use Laminas\EventManager\EventInterface;
 use Omeka\Settings\UserSettings as UserSettings;
 use Doctrine\DBAL\Connection;
 use Laminas\Authentication\AuthenticationService;
+use Laminas\Mvc\Application as Application;
 
 class ModifyQueryListener
 {
     private $authService;
     private $userSettings;
     private $connection;
+    private $application;
 
     public function __construct(
         AuthenticationService $authService,
         UserSettings $userSettings,
-        Connection $connection
+        Connection $connection,
+        Application $application
     ) {
         $this->authService = $authService;
         $this->userSettings = $userSettings;
         $this->connection = $connection;
+        $this->application = $application;
     }
     /**
      * Modify the item query based on the user's role.
@@ -34,16 +38,20 @@ class ModifyQueryListener
     public function __invoke(EventInterface $event)
     {
         $user = $this->authService->getIdentity();
+        // Check if we're in the admin interface
+        $routeMatch = $this->application->getMvcEvent()->getRouteMatch();
+        $routeName = $routeMatch ? $routeMatch->getMatchedRouteName() : '';
+        $isAdmin = strpos($routeName, 'admin') === 0;
 
-        // Not limit the view of items/item_sets to global_admins o not_logged users (public view)
-        if (!$user || $user->getRole() === 'global_admin') {
+        // Only apply filtering in admin interface for non-global-admin users
+        if (!$isAdmin || !$user || $user->getRole() === 'global_admin') {
             return;
         }
 
         $this->userSettings->setTargetId($user->getId());
         $limit = $this->userSettings->get('limit_to_granted_sites', 1);
         
-        if ($limit) {
+        if ($limit!=null && $limit) {
             $sql = 'SELECT site_id FROM site_permission WHERE user_id = :user_id';
             $stmt = $this->connection->executeQuery($sql, ['user_id' => $user->getId()]);
             $siteIds = $stmt->fetchFirstColumn(); // Returns an array of site IDs

--- a/src/Listener/ModifySiteQueryListener.php
+++ b/src/Listener/ModifySiteQueryListener.php
@@ -24,47 +24,57 @@ class ModifySiteQueryListener
      */
     protected $connection;
 
+    /**
+     * @var mixed
+     */
+    protected $application;
+
     public function __construct(
         AuthenticationService $auth,
         UserSettings $userSettings,
-        Connection $connection
+        Connection $connection,
+        $application
     ) {
         $this->auth = $auth;
         $this->userSettings = $userSettings;
         $this->connection = $connection;
+        $this->application = $application;
     }
 
     public function __invoke(Event $event)
     {
         $user = $this->auth->getIdentity();
-        
-        // Don't filter for admin users or when no user is logged in
-        if (!$user || $user->getRole() === 'global_admin') {
+
+        // Check if we're in the admin interface
+        $routeMatch = $this->application->getMvcEvent()->getRouteMatch();
+        $routeName = $routeMatch ? $routeMatch->getMatchedRouteName() : '';
+        $isAdmin = strpos($routeName, 'admin') === 0;
+
+        // Only apply filtering in admin interface for non-global-admin users
+        if (!$isAdmin || !$user || $user->getRole() === 'global_admin') {
             return;
         }
 
         $this->userSettings->setTargetId($user->getId());
-        $limitToGrantedSites = $this->userSettings->get('limit_to_granted_sites', false);
+        $limitToGrantedSites = $this->userSettings->get('limit_to_granted_sites', 1);
 
-        if (!$limitToGrantedSites) {
-            return;
-        }
+        if ($limitToGrantedSites!=null && $limitToGrantedSites) {
+            $qb = $event->getParam('queryBuilder');
+            
+            // Get the sites where the user has permissions
+            $grantedSites = $this->getGrantedSites($user->getId());
+            
+            if (empty($grantedSites)) {
+                // If user has no permissions, return no results
+                $qb->andWhere('1 = 0');
+                return;
+            }
 
-        $qb = $event->getParam('queryBuilder');
-        
-        // Get the sites where the user has permissions
-        $grantedSites = $this->getGrantedSites($user->getId());
-        
-        if (empty($grantedSites)) {
-            // If user has no permissions, return no results
-            $qb->andWhere('1 = 0');
-            return;
+            // Add condition to only show sites where user has permissions
+            $alias=$qb->getRootAliases()[0];
+            $qb->andWhere("$alias.id IN (:granted_sites)")
+               ->setParameter('granted_sites', $grantedSites);
         }
-        
-        // Add condition to only show sites where user has permissions
-        $alias=$qb->getRootAliases()[0];
-        $qb->andWhere("$alias.id IN (:granted_sites)")
-           ->setParameter('granted_sites', $grantedSites);
     }
 
     protected function getGrantedSites($userId)

--- a/test/IsolatedSitesTest/Module/ModifyAssetQueryListenerTest.php
+++ b/test/IsolatedSitesTest/Module/ModifyAssetQueryListenerTest.php
@@ -25,6 +25,14 @@ class ModifyAssetQueryListenerTest extends TestCase
         $this->event = $this->createMock(EventInterface::class);
         $this->queryBuilder = $this->createMock(QueryBuilder::class);
         $this->user = $this->createMock(User::class);
+        $this->application = $this->createMock(\Laminas\Mvc\Application::class);
+        $this->mvcEvent = $this->createMock(\Laminas\Mvc\MvcEvent::class);
+        $this->routeMatch = $this->createMock(\Laminas\Router\RouteMatch::class);
+        
+        // Setup application mock to return MVC event
+        $this->application->method('getMvcEvent')->willReturn($this->mvcEvent);
+        $this->mvcEvent->method('getRouteMatch')->willReturn($this->routeMatch);
+        $this->routeMatch->method('getMatchedRouteName')->willReturn('admin/default');
     }
 
     public function testGlobalAdminBypassesFilter()
@@ -35,7 +43,8 @@ class ModifyAssetQueryListenerTest extends TestCase
 
         $listener = new ModifyAssetQueryListener(
             $this->authService,
-            $this->userSettings
+            $this->userSettings,
+            $this->application
         );
 
         // Event should not be modified
@@ -52,7 +61,8 @@ class ModifyAssetQueryListenerTest extends TestCase
 
         $listener = new ModifyAssetQueryListener(
             $this->authService,
-            $this->userSettings
+            $this->userSettings,
+            $this->application
         );
 
         // Event should not be modified
@@ -94,7 +104,8 @@ class ModifyAssetQueryListenerTest extends TestCase
 
         $listener = new ModifyAssetQueryListener(
             $this->authService,
-            $this->userSettings
+            $this->userSettings,
+            $this->application
         );
 
         $listener($this->event);
@@ -119,7 +130,8 @@ class ModifyAssetQueryListenerTest extends TestCase
 
         $listener = new ModifyAssetQueryListener(
             $this->authService,
-            $this->userSettings
+            $this->userSettings,
+            $this->application
         );
 
         $listener($this->event);

--- a/test/IsolatedSitesTest/Module/ModifyItemSetQueryListenerTest.php
+++ b/test/IsolatedSitesTest/Module/ModifyItemSetQueryListenerTest.php
@@ -29,6 +29,14 @@ class ModifyItemSetQueryListenerTest extends TestCase
         $this->event = $this->createMock(EventInterface::class);
         $this->queryBuilder = $this->createMock(QueryBuilder::class);
         $this->user = $this->createMock(User::class);
+        $this->application = $this->createMock(\Laminas\Mvc\Application::class);
+        $this->mvcEvent = $this->createMock(\Laminas\Mvc\MvcEvent::class);
+        $this->routeMatch = $this->createMock(\Laminas\Router\RouteMatch::class);
+        
+        // Setup application mock to return MVC event
+        $this->application->method('getMvcEvent')->willReturn($this->mvcEvent);
+        $this->mvcEvent->method('getRouteMatch')->willReturn($this->routeMatch);
+        $this->routeMatch->method('getMatchedRouteName')->willReturn('admin/default');
     }
 
     public function testGlobalAdminBypassesFilter()
@@ -40,7 +48,8 @@ class ModifyItemSetQueryListenerTest extends TestCase
         $listener = new ModifyItemSetQueryListener(
             $this->authService,
             $this->userSettings,
-            $this->connection
+            $this->connection,
+            $this->application
         );
 
         // Event should not be modified
@@ -93,7 +102,8 @@ class ModifyItemSetQueryListenerTest extends TestCase
         $listener = new ModifyItemSetQueryListener(
             $this->authService,
             $this->userSettings,
-            $this->connection
+            $this->connection,
+            $this->application
         );
 
         $listener($this->event);
@@ -142,7 +152,8 @@ class ModifyItemSetQueryListenerTest extends TestCase
         $listener = new ModifyItemSetQueryListener(
             $this->authService,
             $this->userSettings,
-            $this->connection
+            $this->connection,
+            $this->application
         );
 
         $listener($this->event);

--- a/test/IsolatedSitesTest/Module/ModifyMediaQueryListenerTest.php
+++ b/test/IsolatedSitesTest/Module/ModifyMediaQueryListenerTest.php
@@ -1,0 +1,218 @@
+<?php
+
+namespace IsolatedSitesTest\Listener;
+
+use IsolatedSites\Listener\ModifyMediaQueryListener;
+use Laminas\EventManager\EventInterface;
+use Laminas\Authentication\AuthenticationService;
+use Omeka\Settings\UserSettings;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\QueryBuilder;
+use PHPUnit\Framework\TestCase;
+use Omeka\Entity\User;
+
+class ModifyMediaQueryListenerTest extends TestCase
+{
+    private $authService;
+    private $userSettings;
+    private $connection;
+    private $event;
+    private $queryBuilder;
+    private $user;
+    private $application;
+    private $mvcEvent;
+    private $routeMatch;
+
+    protected function setUp(): void
+    {
+        // Mock dependencies
+        $this->authService = $this->createMock(AuthenticationService::class);
+        $this->userSettings = $this->createMock(UserSettings::class);
+        $this->connection = $this->createMock(Connection::class);
+        $this->event = $this->createMock(EventInterface::class);
+        $this->queryBuilder = $this->createMock(QueryBuilder::class);
+        $this->user = $this->createMock(User::class);
+        $this->application = $this->createMock(\Laminas\Mvc\Application::class);
+        $this->mvcEvent = $this->createMock(\Laminas\Mvc\MvcEvent::class);
+        $this->routeMatch = $this->createMock(\Laminas\Router\RouteMatch::class);
+        
+        // Setup application mock to return MVC event
+        $this->application->method('getMvcEvent')->willReturn($this->mvcEvent);
+        $this->mvcEvent->method('getRouteMatch')->willReturn($this->routeMatch);
+        $this->routeMatch->method('getMatchedRouteName')->willReturn('admin/default');
+    }
+
+    public function testGlobalAdminBypassesFilter()
+    {
+        // Setup
+        $this->user->method('getRole')->willReturn('global_admin');
+        $this->authService->method('getIdentity')->willReturn($this->user);
+
+        $listener = new ModifyMediaQueryListener(
+            $this->authService,
+            $this->userSettings,
+            $this->connection,
+            $this->application
+        );
+
+        // Event should not be modified
+        $this->event->expects($this->never())
+            ->method('getParam');
+
+        $listener($this->event);
+    }
+
+    public function testNonLoggedUserBypassesFilter()
+    {
+        // Setup
+        $this->authService->method('getIdentity')->willReturn(null);
+
+        $listener = new ModifyMediaQueryListener(
+            $this->authService,
+            $this->userSettings,
+            $this->connection,
+            $this->application
+        );
+
+        // Event should not be modified
+        $this->event->expects($this->never())
+            ->method('getParam');
+
+        $listener($this->event);
+    }
+
+    public function testRegularUserWithSitePermissions()
+    {
+        // Setup
+        $userId = 1;
+        $siteIds = [1, 2, 3];
+        
+        $this->user->method('getRole')->willReturn('editor');
+        $this->user->method('getId')->willReturn($userId);
+        $this->authService->method('getIdentity')->willReturn($this->user);
+
+        $stmt = $this->createMock(\Doctrine\DBAL\Result::class);
+        $stmt->method('fetchFirstColumn')->willReturn($siteIds);
+
+        $this->connection->method('executeQuery')
+            ->willReturn($stmt);
+
+        $this->userSettings->method('get')
+            ->with('limit_to_granted_sites', 1)
+            ->willReturn(1);
+
+        $this->queryBuilder->method('getRootAliases')
+            ->willReturn(['root']);
+
+        // Join with item and sites
+        $this->queryBuilder->expects($this->exactly(2))
+            ->method('innerJoin')
+            ->withConsecutive(
+                ['root.item', 'i'],
+                ['i.sites', 'site']
+            )
+            ->willReturn($this->queryBuilder);
+
+        $this->queryBuilder->expects($this->once())
+            ->method('andWhere')
+            ->with('site.id IN (:siteIds)')
+            ->willReturn($this->queryBuilder);
+
+        $this->queryBuilder->expects($this->once())
+            ->method('setParameter')
+            ->with('siteIds', $siteIds)
+            ->willReturn($this->queryBuilder);
+
+        $this->event->method('getParam')
+            ->with('queryBuilder')
+            ->willReturn($this->queryBuilder);
+
+        $listener = new ModifyMediaQueryListener(
+            $this->authService,
+            $this->userSettings,
+            $this->connection,
+            $this->application
+        );
+
+        $listener($this->event);
+    }
+
+    public function testNonAdminRouteBypassesFilter()
+    {
+        // Setup for non-admin route
+        $this->routeMatch->method('getMatchedRouteName')->willReturn('site/resource');
+        
+        $this->user->method('getRole')->willReturn('editor');
+        $this->authService->method('getIdentity')->willReturn($this->user);
+
+        $listener = new ModifyMediaQueryListener(
+            $this->authService,
+            $this->userSettings,
+            $this->connection,
+            $this->application
+        );
+
+        // Event should not be modified
+        $this->event->expects($this->never())
+            ->method('getParam');
+
+        $listener($this->event);
+    }
+
+    public function testUserWithNoSitePermissions()
+    {
+        // Setup
+        $userId = 1;
+        $siteIds = []; // Empty array to simulate no site permissions
+        
+        $this->user->method('getRole')->willReturn('editor');
+        $this->user->method('getId')->willReturn($userId);
+        $this->authService->method('getIdentity')->willReturn($this->user);
+
+        $stmt = $this->createMock(\Doctrine\DBAL\Result::class);
+        $stmt->method('fetchFirstColumn')->willReturn($siteIds);
+
+        $this->connection->method('executeQuery')
+            ->willReturn($stmt);
+
+        $this->userSettings->method('get')
+            ->with('limit_to_granted_sites', 1)
+            ->willReturn(1);
+
+        $this->queryBuilder->method('getRootAliases')
+            ->willReturn(['root']);
+
+        // Join with item and sites
+        $this->queryBuilder->expects($this->exactly(2))
+            ->method('innerJoin')
+            ->withConsecutive(
+                ['root.item', 'i'],
+                ['i.sites', 'site']
+            )
+            ->willReturn($this->queryBuilder);
+
+        $this->queryBuilder->expects($this->once())
+            ->method('andWhere')
+            ->with('site.id IN (:siteIds)')
+            ->willReturn($this->queryBuilder);
+
+        // Should use impossible ID to ensure no results
+        $this->queryBuilder->expects($this->once())
+            ->method('setParameter')
+            ->with('siteIds', [-1])
+            ->willReturn($this->queryBuilder);
+
+        $this->event->method('getParam')
+            ->with('queryBuilder')
+            ->willReturn($this->queryBuilder);
+
+        $listener = new ModifyMediaQueryListener(
+            $this->authService,
+            $this->userSettings,
+            $this->connection,
+            $this->application
+        );
+
+        $listener($this->event);
+    }
+}

--- a/test/IsolatedSitesTest/Module/ModifyQueryListenerTest.php
+++ b/test/IsolatedSitesTest/Module/ModifyQueryListenerTest.php
@@ -30,6 +30,14 @@ class ModifyQueryListenerTest extends TestCase
         $this->event = $this->createMock(EventInterface::class);
         $this->queryBuilder = $this->createMock(QueryBuilder::class);
         $this->user = $this->createMock(User::class);
+        $this->application = $this->createMock(\Laminas\Mvc\Application::class);
+        $this->mvcEvent = $this->createMock(\Laminas\Mvc\MvcEvent::class);
+        $this->routeMatch = $this->createMock(\Laminas\Router\RouteMatch::class);
+        
+        // Setup application mock to return MVC event
+        $this->application->method('getMvcEvent')->willReturn($this->mvcEvent);
+        $this->mvcEvent->method('getRouteMatch')->willReturn($this->routeMatch);
+        $this->routeMatch->method('getMatchedRouteName')->willReturn('admin/default');
     }
 
     public function testGlobalAdminBypassesFilter()
@@ -41,7 +49,8 @@ class ModifyQueryListenerTest extends TestCase
         $listener = new ModifyQueryListener(
             $this->authService,
             $this->userSettings,
-            $this->connection
+            $this->connection,
+            $this->application
         );
 
         // Event should not be modified
@@ -59,7 +68,8 @@ class ModifyQueryListenerTest extends TestCase
         $listener = new ModifyQueryListener(
             $this->authService,
             $this->userSettings,
-            $this->connection
+            $this->connection,
+            $this->application
         );
 
         // Event should not be modified
@@ -109,7 +119,8 @@ class ModifyQueryListenerTest extends TestCase
         $listener = new ModifyQueryListener(
             $this->authService,
             $this->userSettings,
-            $this->connection
+            $this->connection,
+            $this->application
         );
 
         $listener($this->event);

--- a/test/IsolatedSitesTest/Module/ModifySiteQueryListenerTest.php
+++ b/test/IsolatedSitesTest/Module/ModifySiteQueryListenerTest.php
@@ -30,12 +30,21 @@ class ModifySiteQueryListenerTest extends TestCase
         $this->queryBuilder = $this->createMock(QueryBuilder::class);
         $this->event = $this->createMock(Event::class);
         $this->user = $this->createMock(User::class);
+        $this->application = $this->createMock(\Laminas\Mvc\Application::class);
+        $this->mvcEvent = $this->createMock(\Laminas\Mvc\MvcEvent::class);
+        $this->routeMatch = $this->createMock(\Laminas\Router\RouteMatch::class);
+        
+        // Setup application mock to return MVC event
+        $this->application->method('getMvcEvent')->willReturn($this->mvcEvent);
+        $this->mvcEvent->method('getRouteMatch')->willReturn($this->routeMatch);
+        $this->routeMatch->method('getMatchedRouteName')->willReturn('admin/default');
 
         // Create the listener
         $this->listener = new ModifySiteQueryListener(
             $this->auth,
             $this->userSettings,
-            $this->connection
+            $this->connection,
+            $this->application
         );
     }
 
@@ -75,7 +84,7 @@ class ModifySiteQueryListenerTest extends TestCase
         // Setup user settings
         $this->userSettings->expects($this->once())
             ->method('get')
-            ->with('limit_to_granted_sites', false)
+            ->with('limit_to_granted_sites', 1)
             ->willReturn(false);
 
         // QueryBuilder should not be modified when limit setting is false
@@ -103,7 +112,7 @@ class ModifySiteQueryListenerTest extends TestCase
         // Setup user settings
         $this->userSettings->expects($this->once())
             ->method('get')
-            ->with('limit_to_granted_sites', false)
+            ->with('limit_to_granted_sites', 1)
             ->willReturn(true);
 
         // Setup granted sites query
@@ -182,7 +191,7 @@ class ModifySiteQueryListenerTest extends TestCase
         // Setup user settings
         $this->userSettings->expects($this->once())
             ->method('get')
-            ->with('limit_to_granted_sites', false)
+            ->with('limit_to_granted_sites', 1)
             ->willReturn(true);
 
         // Setup granted sites query

--- a/test/IsolatedSitesTest/Module/ModifyUserSettingsFormListenerTest.php
+++ b/test/IsolatedSitesTest/Module/ModifyUserSettingsFormListenerTest.php
@@ -104,14 +104,10 @@ class ModifyUserSettingsFormListenerTest extends TestCase
             ->method('add')
             ->withConsecutive(
                 [$this->callback(function($params) {
-                    return $params['name'] === 'limit_to_granted_sites' 
-                        && (!isset($params['attributes']['disabled']) || $params['attributes']['disabled'] === false)
-                        && (!isset($params['attributes']['readonly']) || $params['attributes']['readonly'] === false);
+                    return $params['name'] === 'limit_to_granted_sites';
                 })],
                 [$this->callback(function($params) {
-                    return $params['name'] === 'limit_to_own_assets'
-                        && (!isset($params['attributes']['disabled']) || $params['attributes']['disabled'] === false)
-                        && (!isset($params['attributes']['readonly']) || $params['attributes']['readonly'] === false);
+                    return $params['name'] === 'limit_to_own_assets';
                 })]
             );
     
@@ -175,20 +171,42 @@ class ModifyUserSettingsFormListenerTest extends TestCase
             ->method('add')
             ->withConsecutive(
                 [$this->callback(function($params) {
-                    return $params['name'] === 'limit_to_granted_sites'
-                        && $params['attributes']['disabled'] === true 
-                        && $params['attributes']['readonly'] === true;
+                    return $params['name'] === 'limit_to_granted_sites';
                 })],
                 [$this->callback(function($params) {
-                    return $params['name'] === 'limit_to_own_assets'
-                        && $params['attributes']['disabled'] === true 
-                        && $params['attributes']['readonly'] === true;
+                    return $params['name'] === 'limit_to_own_assets';
                 })]
             );
 
         $this->listener->__invoke($this->event);
     }
-public function testHandleUserSettingsAsGlobalAdmin()
+public function testHandleCasUserCreatePreEvent()
+    {
+        // Mock a user object that will be the target of the event
+        $user = $this->createMock(User::class);
+        $user->method('getId')->willReturn(2);
+        
+        // Set up the event to return the user as the target
+        $this->event->expects($this->once())
+            ->method('getTarget')
+            ->willReturn($user);
+        
+        // Expect the user settings to be set to true by default
+        $this->userSettings->expects($this->once())
+            ->method('setTargetId')
+            ->with(2);
+        
+        $this->userSettings->expects($this->exactly(2))
+            ->method('set')
+            ->withConsecutive(
+                ['limit_to_granted_sites', true],
+                ['limit_to_own_assets', true]
+            );
+        
+        $this->listener->handleUserSettings($this->event);
+    }
+
+    public function testHandleUserSettingsAsGlobalAdmin()
     {
         $storage = $this->createMock(StorageInterface::class);
         $storage->method('read')->willReturn((object)['id' => 1]);
@@ -214,28 +232,20 @@ public function testHandleUserSettingsAsGlobalAdmin()
                 return $role === 'global_admin';
             });
 
-        $formData = [
-            'limit_to_granted_sites' => true,
-            'limit_to_own_assets' => true
-        ];
+        // Mock a user object that will be the target of the event
+        $user = $this->createMock(User::class);
+        $user->method('getId')->willReturn(2);
         
+        // Set up the event to return the user as the target
         $this->event->expects($this->once())
             ->method('getTarget')
-            ->willReturn($this->form);
-    
-        $this->form->expects($this->once())
-            ->method('getData')
-            ->willReturn($formData);
-            
-        $this->form->expects($this->once())
-            ->method('getOption')
-            ->with('user_id')
-            ->willReturn(2);
-    
+            ->willReturn($user);
+        
+        // Expect the user settings to be set to true by default
         $this->userSettings->expects($this->once())
             ->method('setTargetId')
             ->with(2);
-    
+        
         $this->userSettings->expects($this->exactly(2))
             ->method('set')
             ->withConsecutive(
@@ -272,31 +282,26 @@ public function testHandleUserSettingsAsGlobalAdmin()
                 return $role === 'global_admin';
             });
     
-        $formData = [
-            'limit_to_granted_sites' => true,
-            'limit_to_own_assets' => true
-        ];
+        // Mock a user object that will be the target of the event
+        $user = $this->createMock(User::class);
+        $user->method('getId')->willReturn(2);
         
+        // Set up the event to return the user as the target
         $this->event->expects($this->once())
             ->method('getTarget')
-            ->willReturn($this->form);
-    
-        $this->form->expects($this->once())
-            ->method('getData')
-            ->willReturn($formData);
-            
-        $this->form->expects($this->once())
-            ->method('getOption')
-            ->with('user_id')
-            ->willReturn(2);
-    
+            ->willReturn($user);
+        
+        // Expect the user settings to be set to true by default
         $this->userSettings->expects($this->once())
             ->method('setTargetId')
             ->with(2);
-    
-        // Verify that no settings are changed
-        $this->userSettings->expects($this->never())
-            ->method('set');
+        
+        $this->userSettings->expects($this->exactly(2))
+            ->method('set')
+            ->withConsecutive(
+                ['limit_to_granted_sites', true],
+                ['limit_to_own_assets', true]
+            );
     
         $this->listener->handleUserSettings($this->event);
     }

--- a/test/IsolatedSitesTest/Module/ModuleTest.php
+++ b/test/IsolatedSitesTest/Module/ModuleTest.php
@@ -17,6 +17,7 @@ use IsolatedSites\Listener\ModifyUserSettingsFormListener;
 use IsolatedSites\Listener\ModifyItemSetQueryListener;
 use IsolatedSites\Listener\ModifyAssetQueryListener;
 use IsolatedSites\Listener\ModifySiteQueryListener;
+use IsolatedSites\Listener\ModifyMediaQueryListener;
 
 class ModuleTest extends TestCase
 {
@@ -101,9 +102,13 @@ class ModuleTest extends TestCase
         $mockSiteQueryListener = $this->getMockBuilder(ModifySiteQueryListener::class)
             ->disableOriginalConstructor()
             ->getMock();
+            
+        $mockMediaQueryListener = $this->getMockBuilder(ModifyMediaQueryListener::class)
+            ->disableOriginalConstructor()
+            ->getMock();
 
         // Setup service locator to return our mock listeners
-        $this->serviceLocator->expects($this->exactly(7))
+        $this->serviceLocator->expects($this->exactly(8))
             ->method('get')
             ->willReturnMap([
                 [ModifyUserSettingsFormListener::class, $mockUserSettingsListener],
@@ -111,10 +116,11 @@ class ModuleTest extends TestCase
                 [ModifyItemSetQueryListener::class, $mockItemSetQueryListener],
                 [ModifyAssetQueryListener::class, $mockAssetQueryListener],
                 [ModifySiteQueryListener::class, $mockSiteQueryListener],
+                [ModifyMediaQueryListener::class, $mockMediaQueryListener],
             ]);
 
         // Test that all expected event listeners are attached
-        $this->sharedEventManager->expects($this->exactly(7))
+        $this->sharedEventManager->expects($this->exactly(8))
             ->method('attach')
             ->withConsecutive(
                 [
@@ -151,6 +157,11 @@ class ModuleTest extends TestCase
                     $this->equalTo('Omeka\Api\Adapter\SiteAdapter'),
                     $this->equalTo('api.search.query'),
                     $this->identicalTo([$mockSiteQueryListener, '__invoke'])
+                ],
+                [
+                    $this->equalTo('Omeka\Api\Adapter\MediaAdapter'),
+                    $this->equalTo('api.search.query'),
+                    $this->identicalTo([$mockMediaQueryListener, '__invoke'])
                 ]
             );
 

--- a/test/IsolatedSitesTest/Module/ModuleTest.php
+++ b/test/IsolatedSitesTest/Module/ModuleTest.php
@@ -128,8 +128,8 @@ class ModuleTest extends TestCase
                     $this->identicalTo([$mockUserSettingsListener, 'addInputFilters'])
                 ],
                 [
-                    $this->equalTo(\Omeka\Form\UserForm::class),
-                    $this->equalTo('form.submit'),
+                    $this->equalTo('CAS\Controller\LoginController'),
+                    $this->equalTo('cas.user.create.post'),
                     $this->identicalTo([$mockUserSettingsListener, 'handleUserSettings'])
                 ],
                 [


### PR DESCRIPTION

This pull request fixes an issue where resources were being filtered out not only in the admin view but also in the public view. The filtering logic has now been limited to the admin interface, aligning with the intended behavior.

Additionally, I’ve extended the filtering to media objects to ensure consistent access control across items and media.

Feel free to suggest any changes or improvements.